### PR TITLE
Fix RCLONE_DOWNLOAD not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ export default {
         // Save the request method, so we can process responses for HEAD requests appropriately
         const requestMethod = request.method;
 
-        if (rcloneDownload && request.headers.get('user-agent')?.includes('rclone')) {
+        if (rcloneDownload) {
             if (env['BUCKET_NAME'] === "$path") {
                 // Remove leading file/ prefix from the path
                 url.pathname = path.replace(/^file\//, "");

--- a/index.js
+++ b/index.js
@@ -90,13 +90,6 @@ export default {
         // Set upstream target hostname.
         switch (env['BUCKET_NAME']) {
             case "$path":
-                // It doesn't make sense for the bucket name to be in the path if we're
-                // proxying Rclone downloads!
-                if (rcloneDownload) {
-                    return new Response("Check Worker configuration: RCLONE_DOWNLOAD is not compatible with BUCKET_NAME=$path\n",{
-                       status: 500
-                    });
-                }
                 // Bucket name is initial segment of URL path
                 url.hostname = env['B2_ENDPOINT'];
                 break;
@@ -125,9 +118,14 @@ export default {
         // Save the request method, so we can process responses for HEAD requests appropriately
         const requestMethod = request.method;
 
-        if (rcloneDownload) {
-            // Remove leading file/ prefix from the path
-            url.pathname = path.replace(/^file\//, "")
+        if (rcloneDownload && request.headers.get('user-agent')?.includes('rclone')) {
+            if (env['BUCKET_NAME'] === "$path") {
+                // Remove leading file/ prefix from the path
+                url.pathname = path.replace(/^file\//, "");
+            } else {
+                // Remove leading file/{bucket_name}/ prefix from the path 
+                url.pathname = path.replace(/^file\/[^/]+\//, "");
+            }            
         }
 
         // Sign the outgoing request


### PR DESCRIPTION
**Pull Request Description: Correct URL Construction for Backblaze B2 S3-Compatible API in Rclone**

**Background**

Backblaze B2's S3-Compatible API supports two URL formats for accessing buckets:

1. **Bucket as Subdomain:**  
   `https://bucketname.s3.us-east-005.backblazeb2.com`

2. **Bucket in the Path:**  
   `https://s3.us-east-005.backblazeb2.com/bucketname`

Rclone's download request format is `{download_url}/file/{bucket_name}/{path}`.

**Issue**

When `BUCKET_NAME` is set to `$path`, the `RCLONE_DOWNLOAD` variable cannot be set to true. When it is false, the code does not remove the `file/` prefix from `url.pathname`. As a result, the `file` prefix is incorrectly treated as a bucket name when making requests to the Backblaze S3-Compatible API.

When `BUCKET_NAME` is set to `$host` or a specific bucket name, and `RCLONE_DOWNLOAD` is enabled, the `file/` prefix is removed. However, the resulting URL is incorrectly constructed as `https://{{bucketname}}s3.us-east-005.backblazeb2.com/{bucketname}`, which does not correctly point to the file, resulting in delivery issues.

**Fix**

The updated code removes the restriction that prevents setting `RCLONE_DOWNLOAD` to true when `BUCKET_NAME` is `$path`. 

Additionally, it ensures that:

- When `BUCKET_NAME` is `$path`, the `file/` prefix is removed from the URL.

- When `BUCKET_NAME` is `$host` or a specific bucket name, the `file/{bucket_name}/` prefix is removed from the URL.

These changes ensure that the constructed URLs are correctly signed and that files are delivered as intended.

**References**

- [Backblaze B2 S3-Compatible API Documentation](https://www.backblaze.com/docs/cloud-storage-call-the-s3-compatible-api)

- [Rclone B2 Integration Discussion](https://forum.rclone.org/t/backblaze-b2-integration-builds-wrong-url-for-cloudflare-cdn/42056)